### PR TITLE
Parent pom fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,19 +201,6 @@
 					</environments>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,22 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- The following is required if source bundles are to be included -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<id>attach-p2-metadata</id>
+						<phase>package</phase>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This pull request removes a duplicate plugin declaration which triggers a warning during maven build, and also adds a plugin declaration required if source bundles are to be included in the update site (See individual commits for details)